### PR TITLE
Use single repo for all RHEL packages

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -11,9 +11,6 @@ CLONE_REPOS="stable latest"
 
 REMOTE_REPO_ROOT="http://snapshot.repo.scalr.net/scalarizr/current"
 
-RHEL_VERSIONS="5 6 7"
-RHEL_5_ALIASES="5Server"
-RHEL_6_ALIASES="6Server 6.0 6.1 6.2 6.3 6.4 6.5 2013.03 2013.09 2014.03 2014.09 2015.03 latest"
-RHEL_7_ALIASES="7Server 7.0"
+RHEL_VERSIONS="5 5Server 6 6Server 6.0 6.1 6.2 6.3 6.4 6.5 6.6 2013.03 2013.09 2014.03 2014.09 2015.03 7 7Server 7.0 7.1"
 
 WGET_OPTS=("--recursive" "--no-directories" "--timestamping" "--no-parent" "--no-verbose" "--execute" "robots=off")

--- a/steps/10-create-repo-layout.sh
+++ b/steps/10-create-repo-layout.sh
@@ -14,17 +14,16 @@ for repo in ${CLONE_REPOS}; do
   # Windows setup
   mkdir -p "${LOCAL_REPO_ROOT}/${repo}/win/x86_64"
 
-  # RHEL setup
-  mkdir -p "${LOCAL_REPO_ROOT}/${repo}"/rpm/rhel/{5,6,7}/{x86_64,i386}
+  # RHEL setup (all repos are aliases of "latest")
+  mkdir -p "${LOCAL_REPO_ROOT}/${repo}"/rpm/rhel/latest/{x86_64,i386}
   cd "${LOCAL_REPO_ROOT}/${repo}/rpm/rhel"
-  for alias in ${RHEL_5_ALIASES}; do
-    ln -sfT 5 "${alias}"
-  done
-  for alias in ${RHEL_6_ALIASES}; do
-    ln -sfT 6 "${alias}"
-  done
-  for alias in ${RHEL_7_ALIASES}; do
-    ln -sfT 7 "${alias}"
+  for alias in ${RHEL_VERSIONS}; do
+    if [ -d "${alias}" ] && [ ! -L "${alias}" ]; then
+      # Old versions actually copied to those directories
+      echo "WARNING: removing obsolete ${alias}"
+      rm -rf "${alias}"
+    fi
+    ln -sfT "latest" "${alias}"
   done
 
 done

--- a/steps/40-pull-rpm-packages.sh
+++ b/steps/40-pull-rpm-packages.sh
@@ -8,15 +8,14 @@ source "${SCALR_REPOCONFIG_CONF}"
 remote_base="${REMOTE_REPO_ROOT}/rpm"
 
 for repo in ${CLONE_REPOS}; do
-  remote_repo_base="${remote_base}/${repo}/rhel"
+  remote_repo_base="${remote_base}/${repo}/rhel/latest"
   extra_wget_opts=("--accept" "*.rpm")
 
-  for ver in ${RHEL_VERSIONS}; do
-    for arch in x86_64 i386; do
-      cd "${LOCAL_REPO_ROOT}/${repo}/rpm/rhel/${ver}/${arch}"
-      echo "## mirroring $ver/$arch"
-      wget "${WGET_OPTS[@]}" "${extra_wget_opts[@]}" "${remote_repo_base}/${ver}/${arch}/"
-      createrepo .
-    done
+  for arch in x86_64 i386; do
+    cd "${LOCAL_REPO_ROOT}/${repo}/rpm/rhel/latest/${arch}"
+    echo "## mirroring $arch"
+    wget "${WGET_OPTS[@]}" "${extra_wget_opts[@]}" "${remote_repo_base}/${arch}/"
+    createrepo .
   done
+
 done


### PR DESCRIPTION
As per @maratkomarov , all versions of RHEL have the same packages. Instead of copying separately, we just symlink everything.
